### PR TITLE
Improve form layout with Bootstrap input groups

### DIFF
--- a/enrichment-calculator.html
+++ b/enrichment-calculator.html
@@ -28,28 +28,43 @@
             <form>
               <!-- Inputs -->
               <div class="mb-3">
-                <label class="form-label">Product Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" placeholder="Enter product assay (fraction)" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Product Assay</span>
+                  <input type="number" class="form-control w-50" placeholder="Enter product assay" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
                 <div class="form-text">Fraction of U‑235 in the product stream.</div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Tails Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" placeholder="Enter tails assay (fraction)" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Tails Assay</span>
+                  <input type="number" class="form-control w-50" placeholder="Enter tails assay" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
                 <div class="form-text">Fraction of U‑235 in the waste stream.</div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Feed Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" placeholder="Enter feed assay (fraction)" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Feed Assay</span>
+                  <input type="number" class="form-control w-50" placeholder="Enter feed assay" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
                 <div class="form-text">Fraction of U‑235 in the feed.</div>
               </div>
               <!-- Outputs -->
               <div class="mb-3">
-                <label class="form-label">Feed Quantity (kg U as UF₆)</label>
-                <input type="text" class="form-control w-50" readonly placeholder="Calculated feed quantity">
+                <div class="input-group">
+                  <span class="input-group-text">Feed Quantity</span>
+                  <input type="text" class="form-control w-50" readonly placeholder="Calculated feed quantity">
+                  <span class="input-group-text">kg U as UF₆</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">SWU Quantity (SWU)</label>
-                <input type="text" class="form-control w-50" readonly placeholder="Calculated SWU required">
+                <div class="input-group">
+                  <span class="input-group-text">SWU Quantity</span>
+                  <input type="text" class="form-control w-50" readonly placeholder="Calculated SWU required">
+                  <span class="input-group-text">SWU</span>
+                </div>
               </div>
               <div class="d-flex">
                 <button type="button" class="btn btn-secondary me-2">Clear</button>
@@ -70,29 +85,47 @@
           <div class="accordion-body">
             <form>
               <div class="mb-3">
-                <label class="form-label">EUP Quantity (kg U)</label>
-                <input type="number" class="form-control w-50" placeholder="Enter enriched uranium quantity" step="any" min="0">
+                <div class="input-group">
+                  <span class="input-group-text">EUP Quantity</span>
+                  <input type="number" class="form-control w-50" placeholder="Enter enriched uranium quantity" step="any" min="0">
+                  <span class="input-group-text">kg U</span>
+                </div>
                 <div class="form-text">Mass of enriched uranium product.</div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Product Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Product Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Tails Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Tails Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Feed Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Feed Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Feed Quantity (kg U as UF₆)</label>
-                <input type="text" class="form-control w-50" readonly>
+                <div class="input-group">
+                  <span class="input-group-text">Feed Quantity</span>
+                  <input type="text" class="form-control w-50" readonly>
+                  <span class="input-group-text">kg U as UF₆</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">SWU Quantity (SWU)</label>
-                <input type="text" class="form-control w-50" readonly>
+                <div class="input-group">
+                  <span class="input-group-text">SWU Quantity</span>
+                  <input type="text" class="form-control w-50" readonly>
+                  <span class="input-group-text">SWU</span>
+                </div>
               </div>
               <div class="d-flex">
                 <button type="button" class="btn btn-secondary me-2">Clear</button>
@@ -113,28 +146,46 @@
           <div class="accordion-body">
             <form>
               <div class="mb-3">
-                <label class="form-label">Feed Quantity (kg U as UF₆)</label>
-                <input type="number" class="form-control w-50" step="any" min="0">
+                <div class="input-group">
+                  <span class="input-group-text">Feed Quantity</span>
+                  <input type="number" class="form-control w-50" step="any" min="0">
+                  <span class="input-group-text">kg U as UF₆</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Product Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Product Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Tails Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Tails Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Feed Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Feed Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">EUP Quantity (kg U)</label>
-                <input type="text" class="form-control w-50" readonly>
+                <div class="input-group">
+                  <span class="input-group-text">EUP Quantity</span>
+                  <input type="text" class="form-control w-50" readonly>
+                  <span class="input-group-text">kg U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">SWU Quantity (SWU)</label>
-                <input type="text" class="form-control w-50" readonly>
+                <div class="input-group">
+                  <span class="input-group-text">SWU Quantity</span>
+                  <input type="text" class="form-control w-50" readonly>
+                  <span class="input-group-text">SWU</span>
+                </div>
               </div>
               <div class="d-flex">
                 <button type="button" class="btn btn-secondary me-2">Clear</button>
@@ -155,28 +206,46 @@
           <div class="accordion-body">
             <form>
               <div class="mb-3">
-                <label class="form-label">SWU Quantity (SWU)</label>
-                <input type="number" class="form-control w-50" step="any" min="0">
+                <div class="input-group">
+                  <span class="input-group-text">SWU Quantity</span>
+                  <input type="number" class="form-control w-50" step="any" min="0">
+                  <span class="input-group-text">SWU</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Product Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Product Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Tails Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Tails Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Feed Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Feed Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">EUP Quantity (kg U)</label>
-                <input type="text" class="form-control w-50" readonly>
+                <div class="input-group">
+                  <span class="input-group-text">EUP Quantity</span>
+                  <input type="text" class="form-control w-50" readonly>
+                  <span class="input-group-text">kg U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Feed Quantity (kg U as UF₆)</label>
-                <input type="text" class="form-control w-50" readonly>
+                <div class="input-group">
+                  <span class="input-group-text">Feed Quantity</span>
+                  <input type="text" class="form-control w-50" readonly>
+                  <span class="input-group-text">kg U as UF₆</span>
+                </div>
               </div>
               <div class="d-flex">
                 <button type="button" class="btn btn-secondary me-2">Clear</button>
@@ -197,24 +266,39 @@
           <div class="accordion-body">
             <form>
               <div class="mb-3">
-                <label class="form-label">Feed Price (currency per kg U as UF₆)</label>
-                <input type="number" class="form-control w-50" step="any" min="0">
+                <div class="input-group">
+                  <span class="input-group-text">Feed Price</span>
+                  <input type="number" class="form-control w-50" step="any" min="0">
+                  <span class="input-group-text">currency per kg U as UF₆</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">SWU Price (currency per SWU)</label>
-                <input type="number" class="form-control w-50" step="any" min="0">
+                <div class="input-group">
+                  <span class="input-group-text">SWU Price</span>
+                  <input type="number" class="form-control w-50" step="any" min="0">
+                  <span class="input-group-text">currency per SWU</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Product Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Product Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Feed Assay (% ²³⁵U)</label>
-                <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                <div class="input-group">
+                  <span class="input-group-text">Feed Assay</span>
+                  <input type="number" class="form-control w-50" step="any" min="0" max="1">
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="mb-3">
-                <label class="form-label">Optimum Tails Assay (% ²³⁵U)</label>
-                <input type="text" class="form-control w-50" readonly>
+                <div class="input-group">
+                  <span class="input-group-text">Optimum Tails Assay</span>
+                  <input type="text" class="form-control w-50" readonly>
+                  <span class="input-group-text">% ²³⁵U</span>
+                </div>
               </div>
               <div class="d-flex">
                 <button type="button" class="btn btn-secondary me-2">Clear</button>


### PR DESCRIPTION
## Summary
- integrate Bootstrap input groups for all calculators
- show units inline with each input field

## Testing
- `npm test` *(fails: Could not read package.json)*