### PR TITLE
Fix width of input groups

### DIFF
--- a/enrichment-calculator.html
+++ b/enrichment-calculator.html
@@ -28,41 +28,41 @@
             <form>
               <!-- Inputs -->
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                  <input type="number" class="form-control w-100" placeholder="Enter product assay" step="any" min="0" max="1" value="0.05">
+                  <input type="number" class="form-control" placeholder="Enter product assay" step="any" min="0" max="1" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the product stream.</div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                  <input type="number" class="form-control w-100" placeholder="Enter tails assay" step="any" min="0" max="1" value="0.003">
+                  <input type="number" class="form-control" placeholder="Enter tails assay" step="any" min="0" max="1" value="0.003">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the waste stream.</div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                  <input type="number" class="form-control w-100" placeholder="Enter feed assay" step="any" min="0" max="1" value="0.007">
+                  <input type="number" class="form-control" placeholder="Enter feed assay" step="any" min="0" max="1" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the feed.</div>
               </div>
               <!-- Outputs -->
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                  <input type="text" class="form-control w-100" readonly placeholder="Calculated feed quantity">
+                  <input type="text" class="form-control" readonly placeholder="Calculated feed quantity">
                   <span class="input-group-text">kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">SWU Quantity</span>
-                  <input type="text" class="form-control w-100" readonly placeholder="Calculated SWU required">
+                  <input type="text" class="form-control" readonly placeholder="Calculated SWU required">
                   <span class="input-group-text">SWU</span>
                 </div>
               </div>
@@ -89,45 +89,45 @@
           <div class="accordion-body">
             <form>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">EUP Quantity</span>
-                  <input type="number" class="form-control w-100" placeholder="Enter enriched uranium quantity" step="any" min="0" value="100">
+                  <input type="number" class="form-control" placeholder="Enter enriched uranium quantity" step="any" min="0" value="100">
                   <span class="input-group-text">kg U</span>
                 </div>
                 <div class="form-text">Mass of enriched uranium product.</div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.05">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.003">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.003">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.007">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                  <input type="text" class="form-control w-100" readonly>
+                  <input type="text" class="form-control" readonly>
                   <span class="input-group-text">kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">SWU Quantity</span>
-                  <input type="text" class="form-control w-100" readonly>
+                  <input type="text" class="form-control" readonly>
                   <span class="input-group-text">SWU</span>
                 </div>
               </div>
@@ -154,44 +154,44 @@
           <div class="accordion-body">
             <form>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" value="100">
+                  <input type="number" class="form-control" step="any" min="0" value="100">
                   <span class="input-group-text">kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.05">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.003">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.003">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.007">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">EUP Quantity</span>
-                  <input type="text" class="form-control w-100" readonly>
+                  <input type="text" class="form-control" readonly>
                   <span class="input-group-text">kg U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">SWU Quantity</span>
-                  <input type="text" class="form-control w-100" readonly>
+                  <input type="text" class="form-control" readonly>
                   <span class="input-group-text">SWU</span>
                 </div>
               </div>
@@ -218,44 +218,44 @@
           <div class="accordion-body">
             <form>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">SWU Quantity</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" value="100">
+                  <input type="number" class="form-control" step="any" min="0" value="100">
                   <span class="input-group-text">SWU</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.05">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.003">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.003">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.007">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">EUP Quantity</span>
-                  <input type="text" class="form-control w-100" readonly>
+                  <input type="text" class="form-control" readonly>
                   <span class="input-group-text">kg U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                  <input type="text" class="form-control w-100" readonly>
+                  <input type="text" class="form-control" readonly>
                   <span class="input-group-text">kg U as UF₆</span>
                 </div>
               </div>
@@ -282,37 +282,37 @@
           <div class="accordion-body">
             <form>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Price</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" value="50">
+                  <input type="number" class="form-control" step="any" min="0" value="50">
                   <span class="input-group-text">currency per kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">SWU Price</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" value="100">
+                  <input type="number" class="form-control" step="any" min="0" value="100">
                   <span class="input-group-text">currency per SWU</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.05">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                  <input type="number" class="form-control w-100" step="any" min="0" max="1" value="0.007">
+                  <input type="number" class="form-control" step="any" min="0" max="1" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
-                <div class="input-group">
+                <div class="input-group w-100">
                   <span class="input-group-text">Optimum Tails Assay</span>
-                  <input type="text" class="form-control w-100" readonly>
+                  <input type="text" class="form-control" readonly>
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,15 @@
-.input-group .form-control.w-100 { max-width: 100%; }
-.unit-select, .input-group .form-select.w-auto { width: auto !important; min-width: unset !important; }
+/* Input groups should span the accordion width */
+.input-group.w-100 {
+  width: 100%;
+}
+
+/* Ensure optional unit selectors don't stretch the input group */
+.unit-select,
+.input-group .form-select.w-auto {
+  width: auto !important;
+  min-width: unset !important;
+}
 @media (max-width: 576px) {
-  .input-group .form-control.w-100 { max-width: 100%; }
   .input-group { flex-wrap: wrap; }
   .input-group .input-group-text, .input-group .form-select, .input-group .form-control {
     flex: 1 1 100%;


### PR DESCRIPTION
## Summary
- ensure each input group spans the full accordion width
- clean up styles

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: command not found)*