### PR TITLE
Fix calculator initialization

### DIFF
--- a/calculate.js
+++ b/calculate.js
@@ -355,7 +355,7 @@ function renderHistory() {
 }
 
 // --- DOM Binding ---
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
   // Enter key submits the nearest calculator
   document.body.addEventListener('keydown', e => {
     if (e.key === 'Enter' && document.activeElement.tagName === 'INPUT') {
@@ -461,7 +461,15 @@ document.addEventListener('DOMContentLoaded', () => {
   byId('clear5').addEventListener('click', () => byId('form5').reset());
 
   renderHistory();
-});
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+}
 
 export {
   computeFeedSwuForOneKg,


### PR DESCRIPTION
## Summary
- ensure event handlers are bound when the page is already loaded

## Testing
- `node --check calculate.js`
