### PR TITLE
Fix VS Code config to avoid file CORS errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,13 @@
             "name": "Open HTML in Browser",
             "type": "pwa-chrome",
             "request": "launch",
-            "file": "${workspaceFolder}/enrichment-calculator.html"
+            "url": "http://localhost:8000/enrichment-calculator.html",
+            "webRoot": "${workspaceFolder}",
+            "preLaunchTask": "serve",
+            "serverReadyAction": {
+                "pattern": "Serving HTTP on",
+                "uriFormat": "http://localhost:8000/enrichment-calculator.html"
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "serve",
+            "type": "shell",
+            "command": "python3",
+            "args": ["-m", "http.server", "8000"],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [],
+            "isBackground": true,
+            "presentation": {
+                "reveal": "silent"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ A lightweight, browser-based tool for exploring uranium enrichment scenarios. Al
    Then open [`http://localhost:8000/enrichment-calculator.html`](http://localhost:8000/enrichment-calculator.html) in your browser.
    Opening the HTML file directly with the `file://` scheme may trigger strict CORS
    rules in modern browsers and prevent `calculate.js` from loading.
+   If you use VS Code, the included **Open HTML in Browser** launch configuration
+   starts this server automatically and opens the page for you.
 3. Enter your desired inputs and press **Calculate**.
 4. Results are copied to your clipboard and also appear in the history panel.
 


### PR DESCRIPTION
## Summary
- update launch.json to open the calculator via `http://localhost` and start a local server
- add `tasks.json` for the `serve` task
- document the VS Code launch configuration in the README

## Testing
- `node -c calculate.js`
- `python3 -m http.server 8000` *(started and terminated)*