### PR TITLE
Allow fractional input

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A lightweight, browser-based tool for exploring uranium enrichment scenarios. Al
 Each calculation automatically copies its result to the clipboard and is logged in the on-page history section for later reference.
 
 ## Usage
-Open `enrichment-calculator.html` in your browser and fill in the values for the desired calculation. Press **Calculate** to see the results. Use the **Clear** button to reset a form if needed. No build step or server is required—everything runs entirely in the browser.
+Open `enrichment-calculator.html` in your browser and fill in the values for the desired calculation. Press **Calculate** to see the results. Use the **Clear** button to reset a form if needed. All numeric fields accept decimal or fractional input like `1/2`. No build step or server is required—everything runs entirely in the browser.
 
 ## Live Site
 A live demo is available at [bennyhartnett.com/enrichment-calculator.html](https://bennyhartnett.com/enrichment-calculator.html).

--- a/calculate.js
+++ b/calculate.js
@@ -51,6 +51,26 @@ function copyToClipboard(text) {
   navigator.clipboard.writeText(text).catch(err => console.error('Copy failed', err));
 }
 
+/**
+ * parseFraction
+ * Parses a decimal or fraction string like "1/2" into a number.
+ * Returns NaN if parsing fails.
+ * @param {string} str
+ * @returns {number}
+ */
+function parseFraction(str) {
+  str = str.trim();
+  if (str.includes('/')) {
+    const parts = str.split('/');
+    if (parts.length !== 2) return NaN;
+    const num = parseFloat(parts[0]);
+    const den = parseFloat(parts[1]);
+    if (isNaN(num) || isNaN(den) || den === 0) return NaN;
+    return num / den;
+  }
+  return parseFloat(str);
+}
+
 // --- Input Parsers ---
 /**
  * parseAssay
@@ -103,13 +123,13 @@ function parseAssay(raw, unitSelect) {
  */
 function parseMass(raw, unitSelect) {
   raw = raw.trim();
-  const match = raw.match(/^([\d.]+)\s*(kg|g|lb)$/i);
+  const match = raw.match(/^([\d./]+)\s*(kg|g|lb)$/i);
   let num, unit;
   if (match) {
-    num = parseFloat(match[1]);
+    num = parseFraction(match[1]);
     unit = match[2].toLowerCase();
   } else {
-    num = parseFloat(raw);
+    num = parseFraction(raw);
     unit = unitSelect.value;
   }
   if (isNaN(num) || num <= 0) throw new Error('Mass must be a positive number');
@@ -129,7 +149,7 @@ function parseMass(raw, unitSelect) {
  * @throws Error if invalid or ≤ 0
  */
 function parseNumeric(raw) {
-  const val = parseFloat(raw);
+  const val = parseFraction(raw);
   if (isNaN(val) || val <= 0) throw new Error('Value must be a positive number');
   return val;
 }

--- a/enrichment-calculator.html
+++ b/enrichment-calculator.html
@@ -31,7 +31,7 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                  <input id="xp1" type="number" class="form-control" placeholder="Enter product assay" step="any" min="0" max="1" value="0.05">
+                  <input id="xp1" type="text" class="form-control" placeholder="Enter product assay" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the product stream.</div>
@@ -39,7 +39,7 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                  <input id="xw1" type="number" class="form-control" placeholder="Enter tails assay" step="any" min="0" max="1" value="0.003">
+                  <input id="xw1" type="text" class="form-control" placeholder="Enter tails assay" value="0.003">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the waste stream.</div>
@@ -47,7 +47,7 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                  <input id="xf1" type="number" class="form-control" placeholder="Enter feed assay" step="any" min="0" max="1" value="0.007">
+                  <input id="xf1" type="text" class="form-control" placeholder="Enter feed assay" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the feed.</div>
@@ -94,7 +94,7 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">EUP Quantity</span>
-                    <input id="p2" type="number" class="form-control" placeholder="Enter enriched uranium quantity" step="any" min="0" value="100">
+                    <input id="p2" type="text" class="form-control" placeholder="Enter enriched uranium quantity" value="100">
                   <span class="input-group-text">kg U</span>
                 </div>
                 <div class="form-text">Mass of enriched uranium product.</div>
@@ -102,21 +102,21 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                    <input id="xp2" type="number" class="form-control" step="any" min="0" max="1" value="0.05">
+                    <input id="xp2" type="text" class="form-control" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                    <input id="xw2" type="number" class="form-control" step="any" min="0" max="1" value="0.003">
+                    <input id="xw2" type="text" class="form-control" value="0.003">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                    <input id="xf2" type="number" class="form-control" step="any" min="0" max="1" value="0.007">
+                    <input id="xf2" type="text" class="form-control" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
@@ -162,28 +162,28 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                    <input id="F3" type="number" class="form-control" step="any" min="0" value="100">
+                    <input id="F3" type="text" class="form-control" value="100">
                   <span class="input-group-text">kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                    <input id="xp3" type="number" class="form-control" step="any" min="0" max="1" value="0.05">
+                    <input id="xp3" type="text" class="form-control" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                    <input id="xw3" type="number" class="form-control" step="any" min="0" max="1" value="0.003">
+                    <input id="xw3" type="text" class="form-control" value="0.003">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                    <input id="xf3" type="number" class="form-control" step="any" min="0" max="1" value="0.007">
+                    <input id="xf3" type="text" class="form-control" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
@@ -229,28 +229,28 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">SWU Quantity</span>
-                    <input id="S4" type="number" class="form-control" step="any" min="0" value="100">
+                    <input id="S4" type="text" class="form-control" value="100">
                   <span class="input-group-text">SWU</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                    <input id="xp4" type="number" class="form-control" step="any" min="0" max="1" value="0.05">
+                    <input id="xp4" type="text" class="form-control" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                    <input id="xw4" type="number" class="form-control" step="any" min="0" max="1" value="0.003">
+                    <input id="xw4" type="text" class="form-control" value="0.003">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                    <input id="xf4" type="number" class="form-control" step="any" min="0" max="1" value="0.007">
+                    <input id="xf4" type="text" class="form-control" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
@@ -296,28 +296,28 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Price</span>
-                    <input id="cf5" type="number" class="form-control" step="any" min="0" value="50">
+                    <input id="cf5" type="text" class="form-control" value="50">
                   <span class="input-group-text">currency per kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">SWU Price</span>
-                    <input id="cs5" type="number" class="form-control" step="any" min="0" value="100">
+                    <input id="cs5" type="text" class="form-control" value="100">
                   <span class="input-group-text">currency per SWU</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                    <input id="xp5" type="number" class="form-control" step="any" min="0" max="1" value="0.05">
+                    <input id="xp5" type="text" class="form-control" value="0.05">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                    <input id="xf5" type="number" class="form-control" step="any" min="0" max="1" value="0.007">
+                    <input id="xf5" type="text" class="form-control" value="0.007">
                   <span class="input-group-text">% ²³⁵U</span>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add generic parseFraction helper
- support fractions in parseMass and parseNumeric
- switch numeric form inputs to `type="text"`
- mention fractional support in README

## Testing
- `node --check calculate.js`