### PR TITLE
Add hyperlink to Centrus homepage on logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <p align="center">
   <!-- Approximated Centrus Energy logo. Replace with official artwork if available. -->
-  <img src="assets/Centrus-Logo-Color-1-400x222.svg" alt="Centrus Energy Logo" width="240"/>
+  <a href="https://www.centrusenergy.com/">
+    <img src="assets/Centrus-Logo-Color-1-400x222.svg" alt="Centrus Energy Logo" width="240"/>
+  </a>
 </p>
 
 A lightweight, browser-based tool for exploring uranium enrichment scenarios. All calculations run entirely client-side using plain JavaScript, so the page works offline after the initial load. Created for Centrus Energy.

--- a/enrichment-calculator.html
+++ b/enrichment-calculator.html
@@ -13,7 +13,9 @@
 </head>
 <body>
   <div class="container mt-5">
-    <img src="assets/Centrus-Logo-Color-1-400x222.svg" alt="Centrus Energy Logo" width="240" class="mb-3" />
+    <a href="https://www.centrusenergy.com/">
+      <img src="assets/Centrus-Logo-Color-1-400x222.svg" alt="Centrus Energy Logo" width="240" class="mb-3" />
+    </a>
     <h1 class="mb-4">Uranium Enrichment Calculators</h1>
 
     <div class="accordion" id="calcModes">


### PR DESCRIPTION
## Summary
- add Centrus Energy homepage link to the logo in README
- link the logo on the calculator page to the official Centrus site

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: command not found)*
