### PR TITLE
Add interactive unit conversion

### DIFF
--- a/enrichment-calculator.html
+++ b/enrichment-calculator.html
@@ -42,24 +42,24 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                  <input id="xp1" type="text" class="form-control" placeholder="Enter product assay" value="0.05">
-                  <span class="input-group-text">% ²³⁵U</span>
+                  <input id="xp1" type="text" class="form-control assay-field" placeholder="Enter product assay" value="0.05">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the product stream.</div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                  <input id="xw1" type="text" class="form-control" placeholder="Enter tails assay" value="0.003">
-                  <span class="input-group-text">% ²³⁵U</span>
+                  <input id="xw1" type="text" class="form-control assay-field" placeholder="Enter tails assay" value="0.003">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the waste stream.</div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                  <input id="xf1" type="text" class="form-control" placeholder="Enter feed assay" value="0.007">
-                  <span class="input-group-text">% ²³⁵U</span>
+                  <input id="xf1" type="text" class="form-control assay-field" placeholder="Enter feed assay" value="0.007">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
                 <div class="form-text">Fraction of U‑235 in the feed.</div>
               </div>
@@ -68,8 +68,8 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                  <input id="feed1" type="text" class="form-control" readonly placeholder="Calculated feed quantity">
-                  <span class="input-group-text">kg U as UF₆</span>
+                  <input id="feed1" type="text" class="form-control mass-field" readonly placeholder="Calculated feed quantity">
+                  <span class="input-group-text mass-unit">kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
@@ -105,30 +105,30 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">EUP Quantity</span>
-                    <input id="p2" type="text" class="form-control" placeholder="Enter enriched uranium quantity" value="100">
-                  <span class="input-group-text">kg U</span>
+                    <input id="p2" type="text" class="form-control mass-field" placeholder="Enter enriched uranium quantity" value="100">
+                  <span class="input-group-text mass-unit">kg U</span>
                 </div>
                 <div class="form-text">Mass of enriched uranium product.</div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                    <input id="xp2" type="text" class="form-control" value="0.05">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xp2" type="text" class="form-control assay-field" value="0.05">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                    <input id="xw2" type="text" class="form-control" value="0.003">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xw2" type="text" class="form-control assay-field" value="0.003">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                    <input id="xf2" type="text" class="form-control" value="0.007">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xf2" type="text" class="form-control assay-field" value="0.007">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <hr>
@@ -136,8 +136,8 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                    <input id="feed2" type="text" class="form-control" readonly>
-                  <span class="input-group-text">kg U as UF₆</span>
+                    <input id="feed2" type="text" class="form-control mass-field" readonly>
+                  <span class="input-group-text mass-unit">kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
@@ -173,29 +173,29 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                    <input id="F3" type="text" class="form-control" value="100">
-                  <span class="input-group-text">kg U as UF₆</span>
+                    <input id="F3" type="text" class="form-control mass-field" value="100">
+                  <span class="input-group-text mass-unit">kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                    <input id="xp3" type="text" class="form-control" value="0.05">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xp3" type="text" class="form-control assay-field" value="0.05">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                    <input id="xw3" type="text" class="form-control" value="0.003">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xw3" type="text" class="form-control assay-field" value="0.003">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                    <input id="xf3" type="text" class="form-control" value="0.007">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xf3" type="text" class="form-control assay-field" value="0.007">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <hr>
@@ -203,8 +203,8 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">EUP Quantity</span>
-                    <input id="P3" type="text" class="form-control" readonly>
-                  <span class="input-group-text">kg U</span>
+                    <input id="P3" type="text" class="form-control mass-field" readonly>
+                  <span class="input-group-text mass-unit">kg U</span>
                 </div>
               </div>
               <div class="mb-3">
@@ -247,22 +247,22 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                    <input id="xp4" type="text" class="form-control" value="0.05">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xp4" type="text" class="form-control assay-field" value="0.05">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Tails Assay</span>
-                    <input id="xw4" type="text" class="form-control" value="0.003">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xw4" type="text" class="form-control assay-field" value="0.003">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                    <input id="xf4" type="text" class="form-control" value="0.007">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xf4" type="text" class="form-control assay-field" value="0.007">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <hr>
@@ -270,15 +270,15 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">EUP Quantity</span>
-                    <input id="P4" type="text" class="form-control" readonly>
-                  <span class="input-group-text">kg U</span>
+                    <input id="P4" type="text" class="form-control mass-field" readonly>
+                  <span class="input-group-text mass-unit">kg U</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Quantity</span>
-                    <input id="feed4" type="text" class="form-control" readonly>
-                  <span class="input-group-text">kg U as UF₆</span>
+                    <input id="feed4" type="text" class="form-control mass-field" readonly>
+                  <span class="input-group-text mass-unit">kg U as UF₆</span>
                 </div>
               </div>
               <div class="row g-2">
@@ -308,7 +308,7 @@
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Price</span>
                     <input id="cf5" type="text" class="form-control" value="50">
-                  <span class="input-group-text">currency per kg U as UF₆</span>
+                  <span class="input-group-text mass-unit">currency per kg U as UF₆</span>
                 </div>
               </div>
               <div class="mb-3">
@@ -321,15 +321,15 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Product Assay</span>
-                    <input id="xp5" type="text" class="form-control" value="0.05">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xp5" type="text" class="form-control assay-field" value="0.05">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Feed Assay</span>
-                    <input id="xf5" type="text" class="form-control" value="0.007">
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xf5" type="text" class="form-control assay-field" value="0.007">
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <hr>
@@ -337,8 +337,8 @@
               <div class="mb-3">
                 <div class="input-group w-100">
                   <span class="input-group-text">Optimum Tails Assay</span>
-                    <input id="xw5" type="text" class="form-control" readonly>
-                  <span class="input-group-text">% ²³⁵U</span>
+                    <input id="xw5" type="text" class="form-control assay-field" readonly>
+                  <span class="input-group-text assay-unit">fraction</span>
                 </div>
               </div>
               <div class="row g-2">


### PR DESCRIPTION
## Summary
- cycle assay units between fraction and percent
- toggle mass units through UF₆, U₃O₈ and U metal in kg/lb
- mark inputs and labels to enable clicking

## Testing
- `node -e "require('./calculate.js')"`