### PR TITLE
Show valid style on default inputs

### DIFF
--- a/calculate.js
+++ b/calculate.js
@@ -448,10 +448,6 @@ function init() {
   function validateInput(input) {
     const type = inputParsers[input.id];
     if (!type) return;
-    if (input.value.trim() === input.defaultValue.trim()) {
-      input.classList.remove('is-valid');
-      return;
-    }
     try {
       switch (type) {
         case 'assay':
@@ -471,6 +467,10 @@ function init() {
 
   document.querySelectorAll('form.calculator input:not([readonly])')
     .forEach(inp => inp.addEventListener('input', () => validateInput(inp)));
+
+  // Validate all inputs initially so default values get success styling
+  document.querySelectorAll('form.calculator input:not([readonly])')
+    .forEach(inp => validateInput(inp));
 
   function setupSyncFields() {
     const groups = {};


### PR DESCRIPTION
## Summary
- update input validation to include default values
- validate all inputs when the page loads so defaults show the green check

## Testing
- `node -c calculate.js`
- `node -e "require('./calculate.js')"`