### PR TITLE
Remove unit conversion features

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,11 @@ in the browser:
   the available SWU.
 - **Optimum tails assay** – search for the economic tails assay that minimizes
   cost per kilogram using a golden‑section search.
-- **Input validation** – calculate buttons stay disabled until all inputs are
-  valid, and hovering over a disabled button highlights fields with errors.
 
-Assay inputs use percentages, and numeric fields such as SWU or price can still use fraction syntax. After each calculation the result is automatically copied to your clipboard. Valid entries turn green while any errors are shown using SweetAlert2 dialogs. The page continues to work offline after the initial load and the responsive layout—with an animated gradient background—works well on mobile devices. Pressing **Enter** triggers the nearest calculator.
+Assay inputs use percentages. After each calculation the result is automatically copied to your clipboard. Valid entries turn green while any errors are shown using SweetAlert2 dialogs. The page continues to work offline after the initial load and the responsive layout—with an animated gradient background—works well on mobile devices. Pressing **Enter** triggers the nearest calculator.
 
 ## Usage
-Open `enrichment-calculator.html` in your browser and fill in the values for the desired calculation. Press **Calculate** to see the results. Use the **Clear** button to reset a form if needed. All numeric fields accept decimal or fractional input like `1/2`. No build step or server is required—everything runs entirely in the browser.
+Open `enrichment-calculator.html` in your browser and fill in the values for the desired calculation. Press **Calculate** to see the results. Use the **Clear** button to reset a form if needed. All numeric fields accept decimal input. No build step or server is required—everything runs entirely in the browser.
 
 ## Live Site
 A live demo is available at [bennyhartnett.com/enrichment-calculator.html](https://bennyhartnett.com/enrichment-calculator.html).


### PR DESCRIPTION
## Summary
- drop mass unit toggling and fractional input support
- simplify mass parsing and numeric parsing
- update README to remove fraction references
- disable validation enforcement in HTML forms

## Testing
- `node -c calculate.js`
- `node - <<'NODE'
import * as calc from './calculate.js';
console.log('functions', Object.keys(calc).length);
console.log(calc.computeFeedSwuForOneKg(0.05,0.003,0.007));
NODE`
